### PR TITLE
add : some doc in Allocator + help command in shell

### DIFF
--- a/src/allocator/linked_list.rs
+++ b/src/allocator/linked_list.rs
@@ -4,12 +4,22 @@ use alloc::alloc::{GlobalAlloc, Layout};
 use core::mem;
 use core::ptr;
 
+/// Implements the structure of a linked list.
+///
+/// Here, we consider a heap allocator that is a linked list of free heap segments.
+/// 
+/// Each node holds these values :
+/// * `size` - the size in bytes if the free segment
+/// * `previous` - static reference to the previous memory node
+/// * `next` - static reference to the next memory node
 #[derive(Debug)]
 struct ListNode {
     size: usize,
     previous: Option<&'static mut ListNode>,
     next: Option<&'static mut ListNode>,
 }
+
+
 
 impl ListNode {
     const fn new(size: usize) -> Self {
@@ -27,6 +37,9 @@ impl ListNode {
     }
 }
 
+/// Implements the structure of a memory allocator based on a linked list
+///
+/// It holds a single value `head` which is the first `ListNode` of the associated linked list.
 #[derive(Debug)]
 pub struct LinkedListAllocator {
     head: ListNode,
@@ -38,6 +51,8 @@ impl LinkedListAllocator {
             head: ListNode::new(0),
         }
     }
+    /// Adds a free region to the allocator. It works by placing a new `ListNode` at the front of the allocator with the given size.
+    /// TODO : add the functionnality of list simplification by merging contiguous free regions.
     unsafe fn add_free_region(&mut self, addr: usize, size: usize) {
         assert_eq!(align_up(addr, mem::align_of::<ListNode>()), addr);
         assert!(size >= mem::size_of::<ListNode>());
@@ -77,6 +92,8 @@ impl LinkedListAllocator {
     pub unsafe fn init(&mut self, heap_start: usize, heap_size: usize) {
         self.add_free_region(heap_start, heap_size)
     }
+
+    /// Find the first free region in the allocator that has a size at least equal to the requested one.
     fn find_region(&mut self, size: usize, align: usize) -> Option<(&'static mut ListNode, usize)> {
         let mut current = &mut self.head;
         while let Some(ref mut region) = current.next {
@@ -91,6 +108,13 @@ impl LinkedListAllocator {
         }
         None
     }
+
+    /// Checks whether a given region can hold a value of given size.
+    /// 
+    /// By first comparing `alloc_end` and `region.end_addr()`, we make sure the region has enough space for the value.
+    ///
+    /// Then we check whether the excess size (i.e. the memory space that would be left if the allocator would take this segment) 
+    /// allows to put the remaining memory space into a new free node.
     fn alloc_from_region(region: &ListNode, size: usize, align: usize) -> Result<usize, ()> {
         let alloc_start = align_up(region.start_addr(), align);
         let alloc_end = alloc_start.checked_add(size).ok_or(())?;

--- a/src/allocator/mod.rs
+++ b/src/allocator/mod.rs
@@ -9,7 +9,9 @@ use x86_64::{
 //Will be removed in favor of a custom allocator in the future
 pub mod linked_list;
 
+/// The start adress of the kernel heap.
 pub const HEAP_START: usize = 0x4444_4444_0000;
+/// The size of the kernel heap. It is for now pretty small.
 pub const HEAP_SIZE: usize = 100 * 1024;
 
 #[alloc_error_handler]
@@ -22,6 +24,9 @@ use linked_list::LinkedListAllocator;
 #[global_allocator]
 static ALLOCATOR: Locked<LinkedListAllocator> = Locked::new(LinkedListAllocator::new());
 
+/// Inits the Allocator, responsible for the...
+///
+/// TODO : continue working on this
 pub fn init(
     mapper: &mut impl Mapper<Size4KiB>,
     frame_allocator: &mut impl FrameAllocator<Size4KiB>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,13 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
-// #![feature(alloc_error_handler)]
+#![feature(alloc_error_handler)]
+#![feature(const_mut_refs)]
 // #![feature(abi_x86_interrupt)]
 
 use core::panic::PanicInfo;
 
-// pub mod allocator;
+pub mod allocator;
 pub mod gdt;
 // pub mod interrupts;
 // pub mod keyboard;
@@ -18,7 +19,7 @@ pub mod serial;
 // pub mod task;
 pub mod vga;
 
-// extern crate alloc;
+extern crate alloc;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u32)]

--- a/src/programs/shell.rs
+++ b/src/programs/shell.rs
@@ -38,22 +38,41 @@ pub fn ascii(_: Vec<String>) -> Result<(), ShellErr> {
     Ok(())
 }
 
+pub fn help(list: Vec<String>) -> Result<(), ShellErr> {
+    match list.get(0) {
+        Some(a) => match COMMANDS.get(a) {
+            Some(command) => {
+                println!("{} : \n {}", command.keyword, command.help);
+            }
+            None => println!("No such command."),
+        },
+        None => println!("Expected command keyword."),
+    }
+    Ok(())
+}
+
 lazy_static! {
     /// Main BTreeMap. Contains the bindings `keyword` <=> `command`
     pub static ref COMMANDS: BTreeMap<String, ShellCommand> = {
         let mut commands = BTreeMap::new();
         let test_command = ShellCommand {
             keyword: String::from("test"),
-            help: String::new(),
+            help: String::from("A simple test function."),
             function: _test1,
         };
         commands.insert(String::from("test"), test_command);
         let test_command = ShellCommand {
             keyword: String::from("ascii"),
-            help: String::new(),
+            help: String::from("Launches the ASCIIfluid program."),
             function: ascii,
         };
         commands.insert(String::from("ascii"), test_command);
+        let test_command = ShellCommand {
+            keyword: String::from("help"),
+            help: String::from("help [function_name]\nPrints the help indcations for any function."),
+            function: help,
+        };
+        commands.insert(String::from("help"), test_command);
         commands
     };
 }


### PR DESCRIPTION
The help function take one argument (keyword of a command) and, is possible prints the help string attributes of the associated command.